### PR TITLE
Adding missing Enum values for AssociatedGatewayPersonality Enum in Vport class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
    <modelVersion>4.0.0</modelVersion>
    <groupId>net.nuagenetworks</groupId>
    <artifactId>vspk</artifactId>
-   <version>5.3.2.2</version>
+   <version>5.3.2.3</version>
    <packaging>jar</packaging>
 
    <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/net/nuagenetworks/vspk/v5_0/VPort.java
+++ b/src/main/java/net/nuagenetworks/vspk/v5_0/VPort.java
@@ -80,7 +80,7 @@ public class VPort extends RestObject {
    
    public enum AddressSpoofing { DISABLED, ENABLED, INHERITED };
    
-   public enum AssociatedGatewayPersonality { DC7X50, EVDF, EVDFB, HARDWARE_VTEP, NETCONF_7X50, NSG, NUAGE_210_WBX_32_Q, NUAGE_210_WBX_48_S, OTHER, VRSB, VRSG, VSA, VSG };
+   public enum AssociatedGatewayPersonality { DC7X50, EVDF, EVDFB, HARDWARE_VTEP, NETCONF_7X50, NSG, NSGBR, NSGDUC, NUAGE_210_WBX_32_Q, NUAGE_210_WBX_48_S, OTHER, VDFG, VRSB, VRSG, VSA, VSG };
    
    public enum EntityScope { ENTERPRISE, GLOBAL };
    


### PR DESCRIPTION
Changes: -

- Adding missing Enum values NSGBR, NSGDUC and VDFG for AssociatedGatewayPersonality ENUM in Vport object class.

Testing: -

- No exception when NSGBR, NSGDUC and VDFG are involved.